### PR TITLE
*: fix and simplify vscode release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,13 +86,7 @@ jobs:
 
       - name: Get version
         id: version
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const fs = require('fs')
-            const pkg = JSON.parse(fs.readFileSync('editors/vscode/package.json', 'utf8'))
-            return pkg.version
+        run: echo "result=$(jq -r .version editors/vscode/package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Check if release exists
         id: check
@@ -107,47 +101,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get changelog
-        if: steps.check.outputs.exists == 'false'
-        id: changelog
-        uses: actions/github-script@v7
-        with:
-          result-encoding: string
-          script: |
-            const fs = require('fs')
-            const os = require('os')
-            const path = require('path')
-
-            let notes = 'No changelog available for this release.'
-
-            try {
-              const changelog = fs.readFileSync('editors/vscode/CHANGELOG.md', 'utf8')
-              const sections = changelog.split(/^## /m)
-              const extracted = sections.at(1)?.split('\n').slice(1).join('\n').trim()
-
-              if (extracted) {
-                notes = extracted
-              }
-            } catch {
-              // CHANGELOG.md does not exist, use default message.
-            }
-
-            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'snowcss-'))
-            const tmpFile = path.join(tmpDir, 'changelog.md')
-
-            fs.writeFileSync(tmpFile, notes)
-
-            return tmpFile
-
-      - name: Package and Release
-        if: steps.check.outputs.exists == 'false'
+      - name: Build and upload extension
+        if: steps.check.outputs.exists == 'true'
         run: |
           pnpm vscode:build
           pnpm vscode:package
 
-          gh release create "snowcss-intellisense@${{ steps.version.outputs.result }}" \
-            editors/vscode/*.vsix \
-            --title "snowcss-intellisense@${{ steps.version.outputs.result }}" \
-            --notes-file "${{ steps.changelog.outputs.result }}"
+          gh release upload "snowcss-intellisense@${{ steps.version.outputs.result }}" \
+            editors/vscode/*.vsix
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Removed unnecessary changelog extraction logic
- Simplified version extraction to use `jq`
- Changed `gh release` to not create release, but simply upload artifact

## Related issues

Closes #21

## Checklist

- [ ] Added changeset (if user-facing change)
- [x] Tests pass locally
- [x] Linted with `pnpm check:fix`